### PR TITLE
Add rounded-corners-exclude configuration option

### DIFF
--- a/man/compton.1.asciidoc
+++ b/man/compton.1.asciidoc
@@ -109,6 +109,9 @@ OPTIONS
 *--corner-radius* 'VALUE'::
 	Round the corners of windows. (defaults to 0).
 
+*--rounded-corners-exclude* 'CONDITION'::
+	Exclude conditions for rounded corners.
+
 *--mark-wmwin-focused*::
 	Try to detect WM windows (a non-override-redirect window with no child that has `WM_STATE`) and mark them as active.
 

--- a/src/compton.c
+++ b/src/compton.c
@@ -1763,6 +1763,7 @@ static session_t *session_init(int argc, char **argv, Display *dpy,
 	      c2_list_postprocess(ps, ps->o.blur_background_blacklist) &&
 	      c2_list_postprocess(ps, ps->o.invert_color_list) &&
 	      c2_list_postprocess(ps, ps->o.opacity_rules) &&
+	      c2_list_postprocess(ps, ps->o.rounded_corners_blacklist) &&
 	      c2_list_postprocess(ps, ps->o.focus_blacklist))) {
 		log_error("Post-processing of conditionals failed, some of your rules "
 		          "might not work");
@@ -2090,6 +2091,7 @@ static void session_destroy(session_t *ps) {
 	free_wincondlst(&ps->o.opacity_rules);
 	free_wincondlst(&ps->o.paint_blacklist);
 	free_wincondlst(&ps->o.unredir_if_possible_blacklist);
+	free_wincondlst(&ps->o.rounded_corners_blacklist);
 
 	// Free tracked atom list
 	{

--- a/src/config.c
+++ b/src/config.c
@@ -558,6 +558,8 @@ char *parse_config(options_t *opt, const char *config_file, bool *shadow_enable,
 
 	    .track_wdata = false,
 	    .track_leader = false,
+
+	    .rounded_corners_blacklist = NULL
 	};
 
 	char *ret = NULL;

--- a/src/config.h
+++ b/src/config.h
@@ -236,7 +236,10 @@ typedef struct options {
 	// Don't use EWMH to detect fullscreen applications
 	bool no_ewmh_fullscreen;
 
+	// === Rounded corners related ===
 	int corner_radius;
+	/// Rounded corners blacklist. A linked list of conditions.
+	c2_lptr_t *rounded_corners_blacklist;
 } options_t;
 
 extern const char *const BACKEND_STRS[NUM_BKEND + 1];

--- a/src/config_libconfig.c
+++ b/src/config_libconfig.c
@@ -234,6 +234,8 @@ char *parse_config_libconfig(options_t *opt, const char *config_file, bool *shad
 		opt->active_opacity = normalize_d(dval);
 	// --corner-radius
 	config_lookup_int(&cfg, "corner-radius", &opt->corner_radius);
+	// --rounded-corners-exclude
+	parse_cfg_condlst(&cfg, &opt->rounded_corners_blacklist, "rounded-corners-exclude");
 	// -e (frame_opacity)
 	config_lookup_float(&cfg, "frame-opacity", &opt->frame_opacity);
 	// -c (shadow_enable)

--- a/src/options.c
+++ b/src/options.c
@@ -117,6 +117,9 @@ static void usage(int ret) {
 	    "--corner-radius value\n"
 	    "  Round the corners of windows. (defaults to 0)\n"
 	    "\n"
+	    "--rounded-corners-exclude condition\n"
+	    "  Exclude conditions for rounded corners.\n"
+	    "\n"
 	    "--mark-wmwin-focused\n"
 	    "  Try to detect WM windows and mark them as active.\n"
 	    "\n"
@@ -416,6 +419,7 @@ static const struct option longopts[] = {
     {"log-file", required_argument, NULL, 322},
     {"use-damage", no_argument, NULL, 323},
     {"corner-radius", required_argument, NULL, 324},
+    {"rounded-corners-exclude", required_argument, NULL, 325},
     {"experimental-backends", no_argument, NULL, 733},
     {"monitor-repaint", no_argument, NULL, 800},
     {"diagnostics", no_argument, NULL, 801},
@@ -790,11 +794,15 @@ void get_cfg(options_t *opt, int argc, char *const *argv, bool shadow_enable,
 		P_CASEBOOL(319, no_x_selection);
 		P_CASEBOOL(323, use_damage);
         case 324: opt->corner_radius = atoi(optarg); break;
-		P_CASEBOOL(733, experimental_backends);
-		P_CASEBOOL(800, monitor_repaint);
+		case 325:
+            // --rounded-corners-exclude
+            condlst_add(&opt->rounded_corners_blacklist, optarg);
+            break;
+        P_CASEBOOL(733, experimental_backends);
+        P_CASEBOOL(800, monitor_repaint);
 		case 801: opt->print_diagnostics = true; break;
-		P_CASEBOOL(802, debug_mode);
-		P_CASEBOOL(803, no_ewmh_fullscreen);
+        P_CASEBOOL(802, debug_mode);
+        P_CASEBOOL(803, no_ewmh_fullscreen);
 		default: usage(1); break;
 #undef P_CASEBOOL
 		}

--- a/src/render.c
+++ b/src/render.c
@@ -316,7 +316,7 @@ paint_region(session_t *ps, const struct managed_win *w, int x, int y, int wid, 
 	const bool argb = (w && (win_has_alpha(w) || ps->o.force_win_blend));
 	const bool neg = (w && w->invert_color);
 
-	render(ps, x, y, dx, dy, wid, hei, opacity, argb, neg, (w && !win_is_fullscreen(ps, w) ? w->corner_radius : 0),
+    render(ps, x, y, dx, dy, wid, hei, opacity, argb, neg, (w && !win_is_fullscreen(ps, w) && !c2_match(ps, w, ps->o.rounded_corners_blacklist, NULL) ? w->corner_radius : 0),
 	       pict, (w ? w->paint.ptex : ps->root_tile_paint.ptex), reg_paint,
 #ifdef CONFIG_OPENGL
 	       w ? &ps->glx_prog_win : NULL


### PR DESCRIPTION
Allows the user to selectively disable rounded corners.

Example configuration for preventing Polybar and all windows of type `dock` from being rounded.
```conf
rounded-corners-exclude = [
    "class_g = 'polybar'",
    "window_type = 'dock'"
];
```
